### PR TITLE
Fix Firebase integration for modern API

### DIFF
--- a/main.js
+++ b/main.js
@@ -49,7 +49,6 @@ function initFirebase(reg) {
   if (!messaging) {
     firebase.initializeApp(firebaseConfig);
     messaging = firebase.messaging();
-    messaging.useServiceWorker(reg);
     messaging.onMessage(payload => {
       console.log('Message received', payload);
       if (payload.notification) {


### PR DESCRIPTION
## Summary
- remove deprecated `useServiceWorker()` from Firebase Messaging setup

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_686be151347c8325a60fff234c8bd5ef