### PR TITLE
Fix duplicate push notifications

### DIFF
--- a/main.js
+++ b/main.js
@@ -53,11 +53,8 @@ function initFirebase(reg) {
       console.log('Message received', payload);
       if (payload.notification) {
         const title = payload.notification.title || 'SmartNCC';
-        const options = {
-          body: payload.notification.body,
-          icon: 'https://demo2018prod.smartncc.it/pwa-smartncc/icon-192.png'
-        };
-        new Notification(title, options);
+        const body = payload.notification.body || '';
+        alert(`${title}\n${body}`);
       }
     });
   }

--- a/sw.js
+++ b/sw.js
@@ -47,18 +47,6 @@ self.addEventListener('fetch', event => {
   );
 });
 
-self.addEventListener('push', event => {
-  let data = { title: 'SmartNCC', body: 'Push message received.' };
-  if (event.data) {
-    data = event.data.json();
-  }
-  const options = {
-    body: data.body,
-    icon: 'https://demo2018prod.smartncc.it/pwa-smartncc/icon-192.png',
-    badge: 'https://demo2018prod.smartncc.it/pwa-smartncc/icon-192.png'
-  };
-  event.waitUntil(self.registration.showNotification(data.title, options));
-});
 
 self.addEventListener('notificationclick', event => {
   event.notification.close();


### PR DESCRIPTION
## Summary
- remove push event handler from service worker
- show an alert for foreground messages instead of new Notification

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_b_686bf0ecb12883259745ea4e2f4408e8