### PR TITLE
Fix FCM bucket and notification link support

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,19 @@ is loaded inside the iframe.
   repository. Upload files at 48x48, 72x72, 96x96, 144x144, 192x192 and
   512x512 pixels to the web server so Android can display them in the home
   screen and in notifications.
+
+### Push message format
+
+Data messages sent via Firebase Cloud Messaging should include at least a `title`
+and `body`. A `url` field can also be provided to open a specific page when the
+notification is clicked.
+
+Example payload:
+
+```json
+{
+  "title": "Hello",
+  "body": "You have a new message",
+  "url": "https://example.com/page"
+}
+```

--- a/sw.js
+++ b/sw.js
@@ -17,12 +17,14 @@ self.addEventListener('push', event => {
 
     const title = payload.title || 'SmartNCC';
     const body = payload.body || '';
+    const url = payload.url;
     const options = {
         body,
         icon: '/pwa-smartncc/icon-512.png',
         badge: '/pwa-smartncc/icon-96-monochrome.png',
         tag: 'smartncc-notification' // evita duplicati
     };
+    if (url) options.data = { url };
 
     // 2) Usa waitUntil per non far partire la "site updated in background"
     event.waitUntil(
@@ -34,7 +36,7 @@ const firebaseConfig = {
   apiKey: 'AIzaSyBelyI2xlDDWVbTvCdpmOG0zfY314c9OIY',
   authDomain: 'app-smartncc-firebase.firebaseapp.com',
   projectId: 'app-smartncc-firebase',
-  storageBucket: 'app-smartncc-firebase.firebasestorage.app',
+  storageBucket: 'app-smartncc-firebase.appspot.com',
   messagingSenderId: '274997008741',
   appId: '1:274997008741:web:7ebb8301a727c71aeca98c'
 };
@@ -81,6 +83,7 @@ self.addEventListener('fetch', event => {
 
 self.addEventListener('notificationclick', event => {
   event.notification.close();
+  const url = event.notification.data && event.notification.data.url;
   event.waitUntil(
     clients.matchAll({ type: 'window', includeUncontrolled: true }).then(clientList => {
       for (const client of clientList) {
@@ -89,7 +92,7 @@ self.addEventListener('notificationclick', event => {
         }
       }
       if (clients.openWindow) {
-        return clients.openWindow('/pwa-smartncc/');
+        return clients.openWindow(url || '/pwa-smartncc/');
       }
     })
   );


### PR DESCRIPTION
## Summary
- fix Firebase storage bucket domain in `sw.js`
- add optional URL handling to push notifications
- open payload URL when clicking a notification
- document push message payload format in README

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_686def8a9d1c83259603d71655683e2b