### PR TITLE
Add static iOS share hint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ icon-96.png
 icon-144.png
 icon-192.png
 icon-512.png
+welcome-img-1.png
+get-pwa-smartncc.bat

--- a/index.css
+++ b/index.css
@@ -33,10 +33,10 @@ body {
 }
 
 #hero {
-    flex: 1 0 auto;
+    display: block;
     width: 100%;
-    min-height: 100px;
-    background: #e0e0e0;
+    height: auto;
+    max-width: 100%;
     margin: 1rem 0;
 }
 
@@ -75,18 +75,10 @@ button {
     display: none;
 }
 
-#ios-hint {
-    position: fixed;
-    bottom: 40px;
-    left: 50%;
-    transform: translateX(-50%);
-    font-size: 2rem;
-    animation: bounce 2s infinite;
-    opacity: 0.7;
-}
 
-@keyframes bounce {
-    0%, 20%, 50%, 80%, 100% { transform: translateY(0); }
-    40% { transform: translateY(-10px); }
-    60% { transform: translateY(-5px); }
+.share-icon {
+    width: 1em;
+    height: 1em;
+    vertical-align: middle;
+    margin-left: 0.2em;
 }

--- a/index.html
+++ b/index.html
@@ -13,15 +13,14 @@
         <!-- Logo esteso Wide -->
         <h1>Benvenuto in </h1>
         <img src="/pwa-smartncc/logo-wide.png" alt="SmartNCC" id="wide-logo">
-        <div id="hero"></div>
+        <img src="/pwa-smartncc/welcome-img-1.png" alt="Benvenuto" id="hero">
         <p id="subtitle">Usa l'applicazione per accedere ai servizi in mobilità e ricevere notifiche PUSH.</p>
         <div id="btns">
             <button id="install-btn" class="hidden">Installa App</button>
             <button id="push-enable-btn" class="hidden">Abilita le notifiche PUSH</button>
-            <button id="open-btn" class="hidden">Apri App</button>
+            <button id="open-btn" class="hidden">Apri APP</button>
         </div>
         <div id="instructions" class="hidden"></div>
     </div>
-    <div id="ios-hint" class="hidden">&#x2B06;&#xFE0F;</div>
 </body>
 </html>

--- a/index.js
+++ b/index.js
@@ -3,7 +3,6 @@ let deferredPrompt;
 const installBtn = document.getElementById('install-btn');
 const openBtn = document.getElementById('open-btn');
 const instructions = document.getElementById('instructions');
-const iosHint = document.getElementById('ios-hint');
 
 const isIos = () => /iphone|ipad|ipod/i.test(navigator.userAgent);
 const isInStandaloneMode = () =>
@@ -22,7 +21,6 @@ async function checkInstalled() {
 function showOpenButton() {
     installBtn.classList.add('hidden');
     instructions.classList.add('hidden');
-    iosHint.classList.add('hidden');
     openBtn.classList.remove('hidden');
     openBtn.onclick = () => {
         window.location.href = '/pwa-smartncc/main.html';
@@ -40,6 +38,11 @@ function startInstallPolling() {
     }, 3000);
 }
 
+window.addEventListener('appinstalled', () => {
+    clearInterval(pollId);
+    showOpenButton();
+});
+
 async function init() {
     if (await checkInstalled()) {
         showOpenButton();
@@ -49,8 +52,7 @@ async function init() {
     if (isIos()) {
         instructions.classList.remove('hidden');
         instructions.innerHTML =
-            'Premi il pulsante <strong>Condividi</strong> e poi <strong>Aggiungi alla schermata Home</strong>.';
-        iosHint.classList.remove('hidden');
+            'Premi il pulsante <strong>Condividi <svg class="share-icon" viewBox="0 0 24 24" width="16" height="16" aria-hidden="true"><path d="M12 2l4 4h-3v7h-2V6H8l4-4z"/><path d="M5 10v10h14V10h2v10a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V10h2z"/></svg></strong> e poi <strong>Aggiungi alla schermata Home</strong>.';
         startInstallPolling();
     } else {
         window.addEventListener('beforeinstallprompt', e => {


### PR DESCRIPTION
## Summary
- replace bouncing iOS install hint with an inline share icon
- clean up unused styles

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_686e0585fb748325b3b9eaa0ab860c2c